### PR TITLE
Treat warning as normal when --quiet option is passed

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -44,10 +44,10 @@ if (cliOptions.version) {
 } else {
   new Linter(translateOptions(cliOptions)).execute(cliOptions._).then(
     (result) => {
-      const failed = result.errorCount || result.warningCount;
+      const failed = result.errorCount || (!cliOptions.quiet && result.warningCount);
 
+      console.log(formatTotal(result));
       if (failed) {
-        console.log(formatTotal(result));
         process.exit(1);
       } else {
         process.exit(0);

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -6,9 +6,8 @@ export function formatTotal(results) {
   const problemLabel = total && total === 1 ? 'problem' : 'problems';
   const errorLabel = total && total === 1 ? 'error' : 'errors';
   const warningLabel = total && total === 1 ? 'warning' : 'warnings';
-  return chalk.red.bold(
-    `\u2716 ${total} ${problemLabel} (${results.errorCount} ${errorLabel}, ${results.warningCount} ${warningLabel})\n`
-  );
+  const text = `${total} ${problemLabel} (${results.errorCount} ${errorLabel}, ${results.warningCount} ${warningLabel})\n`
+  return results.errorCount > 0 ? chalk.red.bold(`\u2716 ${text}`) : results.warningCount > 0 ? chalk.yellow.bold(`\u2716 ${text}`) : ` ${text}`;
 }
 
 export function formatResults(results) {


### PR DESCRIPTION
When ```---quiet``` option is passed and there are no errors but some warnings, eslint-parallel returns 1. This is not an expected behavior. So with this change, eslint-parallel returns 0 when ```--quiet``` option is passed and there are no errors but some warnings. Also in this case, the last message color is yellow as well as eslint does.